### PR TITLE
Use "browser" field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "bodec",
   "version": "0.1.0",
   "main": "bodec.js",
+  "browser": "bodec-browser.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/creationix/bodec.git"


### PR DESCRIPTION
The semi-standard "browser" field in package.json can be used to
indicate to various bundlers (Browserify, webpack, etc.) that certain
files should be used over others for browser builds. This commit
uses the "alternate main" method to specify that bodec-browser.js
should be used instead of bodec.js in browser builds of bodec.

See https://gist.github.com/defunctzombie/4339901 for more info.
